### PR TITLE
Fix incorrect double-dequeue after restarting

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -59,7 +59,7 @@ func loadFileInfos(dir string, infoExtractor func(os.DirEntry) (os.FileInfo, err
 
 	files := make([]file, 0, len(fileList))
 	for i := range fileList {
-		if strings.HasPrefix(fileList[i].Name(), segPrefix) {
+		if strings.HasPrefix(fileList[i].Name(), segPrefix) && !strings.HasSuffix(fileList[i].Name(), segOffsetFileSuffix) {
 			info, e := infoExtractor(fileList[i])
 			if e != nil {
 				return nil, e


### PR DESCRIPTION
# Problem

After calling `Close()` on a queue and then reopening the same data directory, it's possible for entries that were already dequeued to show up again in the queue.

# Expected behavior

Entries that were dequeued should not show up again in a subsequent `Dequeue()` call.

# Details

1. Currently, `loadFileInfos()` [reads](https://github.com/linxGnu/pqueue/blob/6e97a0975224f856885510600789c0d36e79bd83/utils.go#L62) all files in the data directory that have the `seg_` prefix, _including offset files_.
2. `loadFileInfos()` [sorts](https://github.com/linxGnu/pqueue/blob/6e97a0975224f856885510600789c0d36e79bd83/utils.go#L75-L77) those files by modification timestamp.
3. When the queue is closed, an 8-byte "segment ending" marker is [written](https://github.com/linxGnu/pqueue/blob/6e97a0975224f856885510600789c0d36e79bd83/segment/v1/segment_writer.go#L30) to the data file, but the offset file is not touched further. This means that the modification timestamp for the data file ends up being later than that of the offset file.
4. After the queue is reopened, since the offset file has an earlier modification timestamp it's placed earlier than the data file in `loadFileInfo()`'s return.
5. Thus, when attempting to dequeue, the offset file is [read](https://github.com/linxGnu/pqueue/blob/6e97a0975224f856885510600789c0d36e79bd83/queue.go#L96) first but reading fails since the offset file doesn't follow the same format as the data file (depending on luck, it might be possible for the offset file to be interpreted as if it was a data file).
6. Since reading the offset file fails, the offset file is [deleted](https://github.com/linxGnu/pqueue/blob/6e97a0975224f856885510600789c0d36e79bd83/queue.go#L120) as part of cleanup of the segment structure. The data file remains behind.
7. `dequeue()` then tries the next file in the list, which is the data file. By this point, the offset file has already been deleted, so `dequeue()` incorrectly reads the data file from the start instead of seeking to the correct offset.